### PR TITLE
[WIP]商品詳細ページ修正(売り切れボタン)

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -33,12 +33,16 @@
         .show-main__item-box__item-price__item-price-detail
           (税込)送料込み
         .show-main__item-box__item-price__item-price-btn
-          - if user_signed_in?
+          - if @items.buyer_id.present?
+            = link_to root_path do
+              売り切れました
+          - elsif user_signed_in?
             - unless current_user.id == @items.seller_id
               = link_to item_buyers_path(@items) do
                 商品購入
           - else
-            = link_to "ログインがまだな方はこちらからお願いします", require_login_items_path, class: 'post'
+            = link_to require_login_items_path do
+              ログインがまだな方はこちらからお願いします
 
         .show-main__item-box__item-detail
           = @items.introduction


### PR DESCRIPTION
# What
商品詳細ページで売り切れていたら購入ボタンを、売り切れと表示しトップページに遷移するようにした。

# Why
商品がが売り切れているのに決済画面へ飛ぶのを防止するため。